### PR TITLE
Add undo command support

### DIFF
--- a/src/main/java/duke/command/UndoCommand.java
+++ b/src/main/java/duke/command/UndoCommand.java
@@ -1,0 +1,50 @@
+package duke.command;
+
+import duke.common.DukeException;
+import duke.storage.Storage;
+import duke.task.TaskList;
+import duke.ui.Ui;
+
+/**
+ * Represents a command to undo a command.
+ *
+ * @author Rama Aryasuta Pangestu
+ */
+public class UndoCommand extends Command {
+    /**
+     * Constructs a command to undo the last command which modifies the task list, which are
+     * the Add, Delete, Mark, and UnMark Command.
+     */
+    public UndoCommand() {}
+
+    /**
+     * Executes the command by undoing the last command which modifies the task list.
+     *
+     * @param ui       the user interface
+     * @param storage  the storage dealing with loading and saving tasks in the save file
+     * @param taskList the task list
+     * @throws DukeException if an error occurs when saving the task list to the save file
+     */
+    @Override
+    public void execute(Ui ui, Storage storage, TaskList taskList) throws DukeException {
+        taskList.undo();
+        ui.addOutput("OK, I've undo-ed the last command.\n");
+        if (taskList.size() > 0) {
+            ui.addOutput("Now here are the tasks in your list:\n");
+            ui.addOutput(taskList.toString());
+        } else {
+            ui.addOutput("Now your list is empty :(\n");
+        }
+        storage.save(taskList);
+    }
+
+    /**
+     * Returns false as this is not an exit command.
+     *
+     * @return false
+     */
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+}

--- a/src/main/java/duke/parser/Parser.java
+++ b/src/main/java/duke/parser/Parser.java
@@ -14,6 +14,7 @@ import duke.command.FindCommand;
 import duke.command.ListCommand;
 import duke.command.MarkCommand;
 import duke.command.UnMarkCommand;
+import duke.command.UndoCommand;
 import duke.common.DukeException;
 import duke.task.Deadline;
 import duke.task.Event;
@@ -49,6 +50,9 @@ public abstract class Parser {
             break;
         case "list":
             command = new ListCommand();
+            break;
+        case "undo":
+            command = new UndoCommand();
             break;
         case "find":
             command = new FindCommand(Parser.parseArgument(args, "find")

--- a/src/main/java/duke/task/Task.java
+++ b/src/main/java/duke/task/Task.java
@@ -121,4 +121,19 @@ public abstract class Task {
         return this.getTaskTypeIcon() + Task.ENCODING_SEPARATOR
                 + this.getStatusIcon() + Task.ENCODING_SEPARATOR + this.description;
     }
+
+    /**
+     * Returns a clone of the task.
+     *
+     * @return a clone of the task
+     */
+    public Task clone() {
+        Task task = null;
+        try {
+            task = Task.decode(this.encode());
+        } catch (DukeException exception) {
+            assert false; // this should never occur
+        }
+        return task;
+    }
 }

--- a/src/test/java/duke/parser/ParserTest.java
+++ b/src/test/java/duke/parser/ParserTest.java
@@ -15,6 +15,7 @@ import duke.command.FindCommand;
 import duke.command.ListCommand;
 import duke.command.MarkCommand;
 import duke.command.UnMarkCommand;
+import duke.command.UndoCommand;
 import duke.common.DukeException;
 
 
@@ -42,6 +43,20 @@ public class ParserTest {
             assertTrue(Parser.parse("list") instanceof ListCommand);
             assertTrue(Parser.parse("list 2") instanceof ListCommand);
             assertTrue(Parser.parse("list list") instanceof ListCommand);
+        } catch (Exception exception) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testUndo() {
+        try {
+            assertFalse(Parser.parse("undo").isExit());
+            assertFalse(Parser.parse("undo 2").isExit());
+            assertFalse(Parser.parse("undo undo").isExit());
+            assertTrue(Parser.parse("undo") instanceof UndoCommand);
+            assertTrue(Parser.parse("undo 2") instanceof UndoCommand);
+            assertTrue(Parser.parse("undo undo") instanceof UndoCommand);
         } catch (Exception exception) {
             fail();
         }

--- a/src/test/java/duke/task/TaskListTest.java
+++ b/src/test/java/duke/task/TaskListTest.java
@@ -21,6 +21,15 @@ public class TaskListTest {
         assertEquals("", taskList.toString());
 
         try {
+            taskList.undo();
+            fail();
+        } catch (DukeException dukeException) {
+            assertEquals("There are no more commands to undo :(", dukeException.getMessage());
+        } catch (Exception exception) {
+            fail();
+        }
+
+        try {
             Task task = new ToDo("todo", false);
             taskList.addTask(task);
             arrayList.add(task);
@@ -124,5 +133,29 @@ public class TaskListTest {
 
         assertEquals(2, taskList.size());
         assertEquals("1. [T][X] todo\n2. [E][ ] event (at: Dec 12, 2012)\n", taskList.toString());
+
+        try {
+            taskList.undo();
+            assertEquals(3, taskList.size());
+            assertEquals("1. [T][X] todo\n2. [D][X] deadline (by: Dec 12, 2022)\n3. [E][ ] event (at: Dec 12, 2012)\n",
+                    taskList.toString());
+            assertEquals("1. [T][X] todo\n2. [D][X] deadline (by: Dec 12, 2022)\n",
+                    taskList.filter(x -> x.getStatusIcon() == 'X').toString());
+            assertEquals("1. [D][X] deadline (by: Dec 12, 2022)\n2. [E][ ] event (at: Dec 12, 2012)\n",
+                    taskList.filter(x -> x.getTaskTypeIcon() != 'T').toString());
+            assertEquals("1. [T][X] todo\n2. [D][X] deadline (by: Dec 12, 2022)\n",
+                    taskList.filter(x -> x.getDescription().contains("d")).toString());
+        } catch (Exception exception) {
+            fail();
+        }
+
+        try {
+            taskList.undo();
+            assertEquals(3, taskList.size());
+            assertEquals("1. [T][X] todo\n2. [D][X] deadline (by: Dec 12, 2022)\n3. [E][X] event (at: Dec 12, 2012)\n",
+                    taskList.toString());
+        } catch (Exception exception) {
+            fail();
+        }
     }
 }


### PR DESCRIPTION
There is no way to undo a command.

This might inconvenience the user if they made an unintentional command
or wants to revert their last command.

Let's add support for undo command. The undo command is executed if the
user enters `undo`.

The undo command will revert the last command which modifies the task
list. Note that the undo command can only undo a command which was made
since Duke is launched (i.e., there is no way to undo a command made in
a previous launch of Duke). Additionally, there is no way to undo
an undo command.